### PR TITLE
Adds new structs (Subframe, RTCM2) and additional fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 It provides interface similar to the official C, C++ and Python libraries.
 
-Tested with GPSD 3.16, proto version 3.11.
+Tested with GPSD 3.16, proto version 3.11 and GPSD 3.22, proto version 3.14
 
 ## Usage
 

--- a/client.go
+++ b/client.go
@@ -316,6 +316,10 @@ func unmarshal(cls string, b []byte) (Report, error) {
 		v = &OSC{}
 	case "DEVICE":
 		v = &DEVICE{}
+	case "SUBFRAME":
+		v = &SUBFRAME{}
+	case "RTCM2":
+		v = &RTCM2{}
 	case "ERROR":
 		v = &ERROR{}
 	default:

--- a/client_test.go
+++ b/client_test.go
@@ -43,6 +43,8 @@ func TestWatchJSON(t *testing.T) {
 	if _, ok := r.(*VERSION); !ok {
 		t.Fatalf("got %T, want a VERSION report", r)
 	}
+	v := r.(*VERSION)
+	t.Logf("testing GPSD v%s, APIv%d.%d", v.Release, v.ProtoMajor, v.ProtoMinor)
 
 	// DEVICES is received on WATCH_ENABLE
 	r = <-g.C()

--- a/structs.go
+++ b/structs.go
@@ -235,3 +235,53 @@ type RAW []byte
 func (r RAW) class() string {
 	return "RAW"
 }
+
+type SUBFRAME struct {
+	Class  string `json:"class"`
+	Device string `json:"device"`
+	GnssId int    `json:"gnssId"`
+	TSV    int    `json:"tSV"`
+	TOW17  int    `json:"TOW17"`
+	Frame  int    `json:"frame,omitempty"`
+	Scaled bool   `json:"scaled"`
+}
+
+func (r *SUBFRAME) class() string {
+	return r.Class
+}
+
+type RTCM2 struct {
+	Class         string  `json:"class"`
+	Type          int     `json:"type"`
+	StationId     int     `json:"station_id"`
+	Zcount        float64 `json:"zcount"`
+	Seqnum        int     `json:"seqnum"`
+	Length        int     `json:"length"`
+	StationHealth int     `json:"station_health"`
+	X             float64 `json:"x,omitempty"`
+	Y             float64 `json:"y,omitempty"`
+	Z             float64 `json:"z,omitempty"`
+	Satellites    []struct {
+		Ident      int  `json:"ident"`
+		Iodl       bool `json:"iodl"`
+		Health     int  `json:"health"`
+		Snr        int  `json:"snr"`
+		HealthEn   bool `json:"health_en"`
+		NewData    bool `json:"new_data"`
+		LosWarning bool `json:"los_warning"`
+		Tou        int  `json:"tou"`
+	} `json:"satellites,omitempty"`
+	System  string  `json:"system,omitempty"`
+	Sense   int     `json:"sense,omitempty"`
+	Datum   string  `json:"datum,omitempty"`
+	Dx      float64 `json:"dx,omitempty"`
+	Dy      float64 `json:"dy,omitempty"`
+	Dz      float64 `json:"dz,omitempty"`
+	Message string  `json:"message,omitempty"`
+	Ar      string  `json:"ar,omitempty"`
+	Sid     string  `json:"sid,omitempty"`
+}
+
+func (r *RTCM2) class() string {
+	return r.Class
+}

--- a/structs.go
+++ b/structs.go
@@ -45,6 +45,9 @@ type SKY struct {
 	Pdop       float64     `json:"pdop,omitempty"`
 	Gdop       float64     `json:"gdop,omitempty"`
 	Satellites []Satellite `json:"satellites"`
+	PRes       float64     `json:"pres,omitempty"`
+	Qual       int32       `json:"qual,omitempty"`
+	USat       int32       `json:"usat,omitempty"`
 }
 
 func (r *SKY) class() string {

--- a/structs.go
+++ b/structs.go
@@ -111,12 +111,12 @@ func (r *ATT) class() string {
 }
 
 type VERSION struct {
-	Class      string  `json:"class"`
-	Release    string  `json:"release"`
-	Rev        string  `json:"rev"`
-	ProtoMajor float64 `json:"proto_major"`
-	ProtoMinor float64 `json:"proto_minor"`
-	Remove     string  `json:"remote,omitempty"`
+	Class      string `json:"class"`
+	Release    string `json:"release"`
+	Rev        string `json:"rev"`
+	ProtoMajor int    `json:"proto_major"`
+	ProtoMinor int    `json:"proto_minor"`
+	Remote     string `json:"remote,omitempty"`
 }
 
 func (r *VERSION) class() string {

--- a/structs.go
+++ b/structs.go
@@ -55,11 +55,16 @@ func (r *SKY) class() string {
 }
 
 type Satellite struct {
-	PRN  float64 `json:"PRN"`
-	Az   float64 `json:"az"`
-	El   float64 `json:"el"`
-	Ss   float64 `json:"ss"`
-	Used bool    `json:"used"`
+	PRN    float64 `json:"PRN"`
+	Az     float64 `json:"az"`
+	El     float64 `json:"el"`
+	FreqId float64 `json:"freqid,omitempty"`
+	GNSSId float64 `json:"gnssid,omitempty"`
+	Health float64 `json:"health,omitempty"`
+	Ss     float64 `json:"ss"`
+	SigId  float64 `json:"sigid,omitempty"`
+	SVId   float64 `json:"svid,omitempty"`
+	Used   bool    `json:"used"`
 }
 
 type GST struct {


### PR DESCRIPTION
New structures created to support `Subframe` and `RTCM2` from JSON output.

Fixed a typo in `VERSION` struct and changed `ProtoMajor` and `ProtoMinor` to integers since GPSD follows stdver rules. This may break existing users who may already convert from float64 in their own code!

Added missing `SKY` fields: `PRes`, `Qual` and `USat` and added an output during `TestWatchJSON` to report on library and server version, which also meant updating the README file.